### PR TITLE
COMP: Use vtkMRMLLabelMapVolumeNode

### DIFF
--- a/RSSLoadableModule/Resources/UI/qSlicerRSSLoadableModuleModuleWidget.ui
+++ b/RSSLoadableModule/Resources/UI/qSlicerRSSLoadableModuleModuleWidget.ui
@@ -53,7 +53,7 @@
        <widget class="qMRMLNodeComboBox" name="InputLabelVolumeMRMLNodeComboBox">
         <property name="nodeTypes">
          <stringlist>
-          <string>vtkMRMLScalarVolumeNode</string>
+          <string>vtkMRMLLabelMapVolumeNode</string>
          </stringlist>
         </property>
         <property name="addEnabled">

--- a/RSSLoadableModule/qSlicerRSSLoadableModuleModuleWidget.cxx
+++ b/RSSLoadableModule/qSlicerRSSLoadableModuleModuleWidget.cxx
@@ -24,7 +24,7 @@
 
 // add by YG
 #include "vtkMRMLNode.h"
-#include "vtkMRMLScalarVolumeNode.h"
+#include "vtkMRMLLabelMapVolumeNode.h"
 #include "vtkImageData.h"
 #include "vtkImageCast.h"
 
@@ -140,7 +140,7 @@ void qSlicerRSSLoadableModuleModuleWidget::onInputLabelVolumeChanged(vtkMRMLNode
         qDebug("onInputLabelVolumeChanged");
         qDebug(node->GetName(), 100);
 
-        vtkMRMLScalarVolumeNode* scalarVolNode = vtkMRMLScalarVolumeNode::SafeDownCast(node);
+        vtkMRMLLabelMapVolumeNode* scalarVolNode = vtkMRMLLabelMapVolumeNode::SafeDownCast(node);
         vtkImageData* vtkImg = scalarVolNode->GetImageData();
 
         double spacing[3];


### PR DESCRIPTION
A new class for labelmap nodes (vtkMRMLLabelmapNode) was introduced into the Slicer core
that replaces the old method of storing segmentation in a vtkMRMLScalarVolumeNode with
a custom “labelmap” attribute set to "1".
See details here:
http://www.slicer.org/slicerWiki/index.php/Documentation/Labs/Segmentations#vtkMRMLLabelMapVolumeNode_integration

This change in the Slicer core requires modification of your extension. See the suggested change in this commit.